### PR TITLE
Zero-byte PUT

### DIFF
--- a/mountpoint-s3-client/src/object_client.rs
+++ b/mountpoint-s3-client/src/object_client.rs
@@ -245,7 +245,7 @@ pub enum GetObjectAttributesError {
 
 /// Parameters to a [ObjectClient::put_object] request
 /// TODO: Populate this struct with parameters from the S3 API, e.g., storage class, encryption.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct PutObjectParams {}
 

--- a/mountpoint-s3-client/src/s3_crt_client/head_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/head_object.rs
@@ -65,6 +65,7 @@ impl S3CrtClient {
     ) -> ObjectClientResult<HeadObjectResult, HeadObjectError, S3RequestError> {
         let request = {
             let mut message = self
+                .inner
                 .new_request_template("HEAD", bucket)
                 .map_err(S3RequestError::construction_failure)?;
 
@@ -80,10 +81,10 @@ impl S3CrtClient {
             let header: Arc<Mutex<Option<Result<HeadObjectResult, ParseError>>>> = Default::default();
             let header1 = header.clone();
 
-            let span = request_span!(self, "head_object");
+            let span = request_span!(self.inner, "head_object");
             span.in_scope(|| debug!(?bucket, ?key, "new request"));
 
-            self.make_meta_request(
+            self.inner.make_meta_request(
                 message,
                 MetaRequestType::Default,
                 span,

--- a/mountpoint-s3-client/src/s3_crt_client/put_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/put_object.rs
@@ -1,11 +1,14 @@
+use std::sync::Arc;
+
 use crate::object_client::{ObjectClientResult, PutObjectError, PutObjectParams};
 use crate::{ObjectClientError, PutObjectRequest, PutObjectResult, S3CrtClient, S3RequestError};
 use async_trait::async_trait;
+use mountpoint_s3_crt::http::request_response::Header;
 use mountpoint_s3_crt::io::async_stream::{self, AsyncStreamWriter};
 use mountpoint_s3_crt::s3::client::MetaRequestType;
 use tracing::debug;
 
-use super::S3HttpRequest;
+use super::{S3CrtClientInner, S3HttpRequest};
 
 impl S3CrtClient {
     pub(super) async fn put_object(
@@ -14,38 +17,66 @@ impl S3CrtClient {
         key: &str,
         params: &PutObjectParams,
     ) -> ObjectClientResult<S3PutObjectRequest, PutObjectError, S3RequestError> {
+        Ok(S3PutObjectRequest::new(
+            self.inner.clone(),
+            bucket.to_owned(),
+            key.to_owned(),
+            params.to_owned(),
+        ))
+    }
+}
+
+type S3PutRequest = (S3HttpRequest<Vec<u8>, PutObjectError>, AsyncStreamWriter);
+
+#[derive(Debug)]
+pub struct S3PutObjectRequest {
+    client: Arc<S3CrtClientInner>,
+    bucket: String,
+    key: String,
+    params: PutObjectParams,
+    inner: Option<S3PutRequest>,
+}
+
+impl S3PutObjectRequest {
+    fn new(client: Arc<S3CrtClientInner>, bucket: String, key: String, params: PutObjectParams) -> Self {
+        Self {
+            client,
+            bucket,
+            key,
+            params,
+            inner: Default::default(),
+        }
+    }
+
+    fn make_request(&self, content_length: Option<usize>) -> Result<S3PutRequest, S3RequestError> {
         let mut message = self
-            .new_request_template("PUT", bucket)
+            .client
+            .new_request_template("PUT", &self.bucket)
             .map_err(S3RequestError::construction_failure)?;
 
-        let key = format!("/{key}");
+        let key = format!("/{}", self.key);
         message
             .set_request_path(&key)
             .map_err(S3RequestError::construction_failure)?;
 
-        let (body_async_stream, writer) = async_stream::new_stream(&self.allocator);
+        let (body_async_stream, writer) = async_stream::new_stream(&self.client.allocator);
         message.set_body_stream(Some(body_async_stream));
 
-        let span = request_span!(self, "put_object");
-        span.in_scope(|| debug!(?bucket, ?key, ?params, "new request"));
+        if let Some(len) = content_length {
+            message
+                .add_header(&Header::new("Content-Length", len.to_string()))
+                .map_err(S3RequestError::construction_failure)?;
+        }
 
-        let body = self.make_simple_http_request(message, MetaRequestType::PutObject, span, |result| {
-            ObjectClientError::ClientError(S3RequestError::ResponseError(result))
-        })?;
+        let span = request_span!(self.client, "put_object");
+        span.in_scope(|| debug!(bucket=?self.bucket, ?key, params=?self.params, "new request"));
 
-        Ok(S3PutObjectRequest::new(body, writer))
-    }
-}
-
-#[derive(Debug)]
-pub struct S3PutObjectRequest {
-    body: S3HttpRequest<Vec<u8>, PutObjectError>,
-    writer: AsyncStreamWriter,
-}
-
-impl S3PutObjectRequest {
-    fn new(body: S3HttpRequest<Vec<u8>, PutObjectError>, writer: AsyncStreamWriter) -> Self {
-        Self { body, writer }
+        let body = self
+            .client
+            .make_simple_http_request(message, MetaRequestType::PutObject, span, |result| {
+                ObjectClientError::ClientError(S3RequestError::ResponseError(result))
+            })?;
+        Ok((body, writer))
     }
 }
 
@@ -54,21 +85,36 @@ impl PutObjectRequest for S3PutObjectRequest {
     type ClientError = S3RequestError;
 
     async fn write(&mut self, slice: &[u8]) -> ObjectClientResult<(), PutObjectError, Self::ClientError> {
-        self.writer
+        let (_, writer) = match &mut self.inner {
+            Some(inner) => inner,
+            None => self.inner.insert(self.make_request(None)?),
+        };
+
+        writer
             .write(slice)
             .await
             .map_err(|e| S3RequestError::InternalError(Box::new(e)).into())
     }
 
     async fn complete(mut self) -> ObjectClientResult<PutObjectResult, PutObjectError, Self::ClientError> {
-        let body = {
-            self.writer
-                .complete()
-                .await
-                .map_err(|e| S3RequestError::InternalError(Box::new(e)))?;
-            self.body
+        let body = match self.inner {
+            Some((body, writer)) => {
+                writer
+                    .complete()
+                    .await
+                    .map_err(|e| S3RequestError::InternalError(Box::new(e)))?;
+                body
+            }
+            None => {
+                // If the request has not started yet, this is an empty object and we need to
+                // set Content-Length=0 on the meta request and immediately drop the writer.
+                let (body, writer) = self.make_request(Some(0))?;
+                drop(writer);
+                body
+            }
         };
-        body.await?;
+
+        _ = body.await?;
         Ok(PutObjectResult {})
     }
 }

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -37,7 +37,7 @@ async fn test_put_object(client: &impl ObjectClient, bucket: &str, prefix: &str)
 
 object_client_test!(test_put_object);
 
-// Simple test for PUT object. Puts a single, empty object as a single part and checks that the
+// Simple test for PUT object. Puts a single, empty object and checks that the (empty)
 // contents are correct with a GET.
 async fn test_put_object_empty(client: &impl ObjectClient, bucket: &str, prefix: &str) {
     let key = format!("{prefix}hello");

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -37,6 +37,27 @@ async fn test_put_object(client: &impl ObjectClient, bucket: &str, prefix: &str)
 
 object_client_test!(test_put_object);
 
+// Simple test for PUT object. Puts a single, empty object as a single part and checks that the
+// contents are correct with a GET.
+async fn test_put_object_empty(client: &impl ObjectClient, bucket: &str, prefix: &str) {
+    let key = format!("{prefix}hello");
+
+    let request = client
+        .put_object(bucket, &key, &Default::default())
+        .await
+        .expect("put_object should succeed");
+
+    request.complete().await.unwrap();
+
+    let result = client
+        .get_object(bucket, &key, None, None)
+        .await
+        .expect("get_object should succeed");
+    check_get_result(result, None, &[]).await;
+}
+
+object_client_test!(test_put_object_empty);
+
 // Test for multi-part PUT interface. Splits up a small object into a number of pieces, and streams
 // the pieces to the object client. Checks contents are correct using a GET.
 async fn test_put_object_multi_part(client: &impl ObjectClient, bucket: &str, prefix: &str) {


### PR DESCRIPTION
Exposes a gap in the new streaming put implementation.

It seems that the CRT does not support empty async input streams:
```
0 byte meta requests without Content-Length header are currently not supported. Set Content-Length header to 0 to upload empty object 
```




---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
