### PR TITLE
Add flag to switch between CRT and our pool for benchmarks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -174,6 +174,8 @@ jobs:
         pool:
         - name: Test Pool
           feature: pool_tests
+        - name: FS Pool
+          feature: fs_pool_tests
 
     steps:
     - name: Configure AWS credentials

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -148,6 +148,64 @@ jobs:
       if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
       run: ./.github/actions/scripts/save-coredump.sh
 
+
+  client-test:
+    name: Client Tests (${{ matrix.bucket-type.name }}, ${{ matrix.runner.name }}, ${{ matrix.pool.name }})
+    runs-on: ${{ matrix.runner.tags }}
+
+    environment: ${{ inputs.environment }}
+    env:
+      features: s3_tests,fips_tests,${{ matrix.pool.feature }},${{ matrix.bucket-type.feature }}
+      packages: --package mountpoint-s3-client --package mountpoint-s3-crt --package mountpoint-s3-crt-sys
+
+    strategy:
+      fail-fast: false
+      matrix:
+        bucket-type:
+        - name: S3
+          feature: 
+        - name: S3 Express One Zone
+          feature: s3express_tests
+        runner:
+        - name: Ubuntu x86
+          tags: [ubuntu-22.04] # GitHub-hosted
+        - name: Amazon Linux arm
+          tags: [self-hosted, linux, arm64]
+        pool:
+        - name: Test Pool
+          feature: pool_tests
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.ACTIONS_IAM_ROLE }}
+        aws-region: ${{ vars.S3_REGION }}
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: true
+        persist-credentials: false
+    - name: Set up Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        # setup-rust-toolchain sets "-D warnings" by default, and Rust treats any warning as compile error.
+        # We need to this currently because `mountpoint-s3-fuser` contains some warnings and it breaks the build.
+        rustflags: ""
+    - name: Install operating system dependencies
+      uses: ./.github/actions/install-dependencies
+      with:
+        # not required for client tests. TODO: make it optional.
+        fuseVersion: 2
+    - name: Build tests
+      run: cargo test ${{ env.packages }} --features '${{ env.features }}' --no-run
+    - name: Run tests
+      run: cargo test ${{ env.packages }} --features '${{ env.features }}'
+    - name: Save dump files
+      if: ${{ failure() && matrix.runner.name == 'Amazon Linux arm' }}
+      run: ./.github/actions/scripts/save-coredump.sh
+
   fstab:
     name: fstab tests (${{ matrix.runner.name }}
     runs-on: ${{ matrix.runner.tags }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,6 +2861,7 @@ dependencies = [
  "metrics",
  "mountpoint-s3-client",
  "mountpoint-s3-crt",
+ "mountpoint-s3-fs",
  "percent-encoding",
  "pin-project",
  "platform-info",

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -66,6 +66,7 @@ mock = ["dep:async-io", "dep:async-lock", "dep:md-5", "dep:rand", "dep:rand_chac
 s3_tests = []
 fips_tests = []
 s3express_tests = []
+pool_tests = []
 
 [lib]
 doctest = false

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -56,6 +56,9 @@ tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 mountpoint-s3-client = { path = ".", features = ["mock"] }
 
+# Required to run the tests using the custom memory pool from the fs crate.
+mountpoint-s3-fs = { path = "../mountpoint-s3-fs" }
+
 [build-dependencies]
 built = { version = "0.8.0", features = ["git2"] }
 
@@ -66,6 +69,7 @@ s3_tests = []
 fips_tests = []
 s3express_tests = []
 pool_tests = []
+fs_pool_tests = []
 
 [lib]
 doctest = false

--- a/mountpoint-s3-client/Cargo.toml
+++ b/mountpoint-s3-client/Cargo.toml
@@ -60,7 +60,6 @@ mountpoint-s3-client = { path = ".", features = ["mock"] }
 built = { version = "0.8.0", features = ["git2"] }
 
 [features]
-restore_buffer_copy = []
 mock = ["dep:async-io", "dep:async-lock", "dep:md-5", "dep:rand", "dep:rand_chacha"]
 # Features for choosing tests
 s3_tests = []

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -40,6 +40,7 @@
 //!
 //! [awscrt]: https://docs.aws.amazon.com/sdkref/latest/guide/common-runtime.html
 
+#![deny(clippy::undocumented_unsafe_blocks)]
 // Make async trait docs not-ugly on docs.rs (https://github.com/dtolnay/async-trait/issues/213)
 #![cfg_attr(docsrs, feature(async_fn_in_trait))]
 
@@ -79,6 +80,8 @@ pub mod config {
     pub use mountpoint_s3_crt::io::io_library_init;
     #[doc(hidden)]
     pub use mountpoint_s3_crt::s3::s3_library_init;
+
+    pub use mountpoint_s3_crt::s3::pool::{MemoryPool, MemoryPoolFactory, MemoryPoolFactoryOptions};
 }
 
 /// Types used by all object clients

--- a/mountpoint-s3-client/src/lib.rs
+++ b/mountpoint-s3-client/src/lib.rs
@@ -63,7 +63,8 @@ pub mod error_metadata;
 pub use object_client::{ObjectClient, PutObjectRequest};
 
 pub use s3_crt_client::{
-    OnTelemetry, S3CrtClient, S3RequestError, get_object::S3GetObjectResponse, put_object::S3PutObjectRequest,
+    NewClientError, OnTelemetry, S3CrtClient, S3RequestError, get_object::S3GetObjectResponse,
+    put_object::S3PutObjectRequest,
 };
 
 /// Configuration for the S3 client

--- a/mountpoint-s3-client/src/s3_crt_client/get_object.rs
+++ b/mountpoint-s3-client/src/s3_crt_client/get_object.rs
@@ -11,21 +11,17 @@ use futures::channel::mpsc::UnboundedReceiver;
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt};
 use mountpoint_s3_crt::http::request_response::{Header, Headers};
-use mountpoint_s3_crt::s3::buffer::Buffer;
 use mountpoint_s3_crt::s3::client::{MetaRequest, MetaRequestResult};
 use pin_project::pin_project;
 use tracing::trace;
 
 use crate::error_metadata::ClientErrorMetadata;
 use crate::object_client::{
-    Checksum, ChecksumMode, ClientBackpressureHandle, GetBodyPart, GetObjectError, GetObjectParams, ObjectClientError,
-    ObjectClientResult, ObjectMetadata,
+    Checksum, ChecksumMode, ClientBackpressureHandle, GetBodyPart, GetObjectError, GetObjectParams, GetObjectResponse,
+    ObjectChecksumError, ObjectClientError, ObjectClientResult, ObjectMetadata,
 };
 
-use super::{
-    CancellingMetaRequest, GetObjectResponse, ObjectChecksumError, ResponseHeadersError, S3CrtClient, S3Operation,
-    S3RequestError, parse_checksum,
-};
+use super::{CancellingMetaRequest, ResponseHeadersError, S3CrtClient, S3Operation, S3RequestError, parse_checksum};
 
 impl S3CrtClient {
     /// Create and begin a new GetObject request. The returned [S3GetObjectResponse] is a [Stream] of
@@ -85,6 +81,7 @@ impl S3CrtClient {
 
             let mut headers_sender = Some(event_sender.clone());
             let part_sender = event_sender.clone();
+
             self.inner.meta_request_with_callbacks(
                 options,
                 span,
@@ -101,10 +98,11 @@ impl S3CrtClient {
                     }
                 },
                 move |offset, data| {
-                    let body_part = GetBodyPart {
-                        offset,
-                        data: make_owned_bytes(data),
-                    };
+                    let owned_buffer = data
+                        .to_owned_buffer()
+                        .expect("buffers returned from GetObject can always be acquired");
+                    let bytes = Bytes::from_owner(owned_buffer);
+                    let body_part = GetBodyPart { offset, data: bytes };
                     _ = part_sender.unbounded_send(S3GetObjectEvent::BodyPart(body_part));
                 },
                 parse_get_object_error,
@@ -148,19 +146,6 @@ impl S3CrtClient {
             next_offset,
         })
     }
-}
-
-#[cfg(not(feature = "restore_buffer_copy"))]
-fn make_owned_bytes(data: &Buffer) -> Bytes {
-    let owned_buffer = data
-        .to_owned_buffer()
-        .expect("buffers returned from GetObject can always be acquired");
-    Bytes::from_owner(owned_buffer)
-}
-
-#[cfg(feature = "restore_buffer_copy")]
-fn make_owned_bytes(data: &Buffer) -> Bytes {
-    Bytes::copy_from_slice(data)
 }
 
 #[derive(Debug)]

--- a/mountpoint-s3-client/tests/auth.rs
+++ b/mountpoint-s3-client/tests/auth.rs
@@ -14,10 +14,10 @@ use tempfile::NamedTempFile;
 use common::creds::{get_sdk_default_chain_creds, get_subsession_iam_role};
 use common::*;
 
+use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::{S3ClientAuthConfig, S3ClientConfig};
 use mountpoint_s3_client::error::ObjectClientError;
 use mountpoint_s3_client::types::GetObjectParams;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_crt::auth::credentials::{CredentialsProvider, CredentialsProviderStaticOptions};
 use mountpoint_s3_crt::common::allocator::Allocator;
 
@@ -51,7 +51,7 @@ async fn test_static_provider() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -71,7 +71,7 @@ async fn test_static_provider() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let _error = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -129,7 +129,7 @@ async fn test_profile_provider_static_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -145,7 +145,7 @@ async fn test_profile_provider_static_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let _error = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -158,7 +158,7 @@ async fn test_profile_provider_static_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile("not-the-right-profile-name".to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let _result = S3CrtClient::new(config).expect_err("profile doesn't exist");
+    let _result = create_client_with_config(config).expect_err("profile doesn't exist");
 }
 
 async fn test_profile_provider_assume_role_async() {
@@ -206,7 +206,7 @@ async fn test_profile_provider_assume_role_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let _error = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -219,7 +219,7 @@ async fn test_profile_provider_assume_role_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(profile_name.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -335,7 +335,7 @@ async fn test_credential_process_behind_source_profile_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(correct_profile.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
     let _result = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}foo/"))
         .await
@@ -345,7 +345,7 @@ async fn test_credential_process_behind_source_profile_async() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Profile(incorrect_profile.to_owned()))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
     let err = client
         .list_objects(&bucket, None, "/", 10, &format!("{prefix}/"))
         .await
@@ -419,7 +419,7 @@ async fn test_scoped_credentials() {
     let config = S3ClientConfig::new()
         .auth_config(S3ClientAuthConfig::Provider(provider))
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(config).unwrap();
+    let client = get_test_client_with_config(config);
 
     // Inside the prefix, things should be fine
     let _result = client

--- a/mountpoint-s3-client/tests/client.rs
+++ b/mountpoint-s3-client/tests/client.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "s3_tests")]
+
+pub mod common;
+
+use common::*;
+use mountpoint_s3_client::S3CrtClient;
+use mountpoint_s3_client::config::S3ClientConfig;
+
+#[tokio::test]
+async fn test_create_client_twice() {
+    let config = set_up_client_config(S3ClientConfig::new().endpoint_config(get_test_endpoint_config()));
+
+    // Attempt to create the client twice.
+    for _i in 0..2 {
+        let _client = S3CrtClient::new(config.clone()).expect("could not create test client");
+    }
+}

--- a/mountpoint-s3-client/tests/common/memory_pool.rs
+++ b/mountpoint-s3-client/tests/common/memory_pool.rs
@@ -1,0 +1,23 @@
+use mountpoint_s3_client::config::MemoryPool;
+
+/// Creates a memory pool to use in tests.
+pub fn new_for_tests() -> impl MemoryPool {
+    NoReusePool()
+}
+
+/// Trivial memory pool implementation that always allocates new buffers.
+#[derive(Debug, Clone)]
+struct NoReusePool();
+
+impl MemoryPool for NoReusePool {
+    type Buffer = Box<[u8]>;
+
+    fn get_buffer(&self, size: usize) -> Self::Buffer {
+        vec![0u8; size].into_boxed_slice()
+    }
+
+    fn trim(&self) -> bool {
+        // Nothing to do.
+        false
+    }
+}

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -78,6 +78,11 @@ pub fn set_up_client_config(config: S3ClientConfig) -> S3ClientConfig {
     #[cfg(feature = "pool_tests")]
     let config = config.memory_pool(memory_pool::new_for_tests());
 
+    #[cfg(feature = "fs_pool_tests")]
+    let config = config.memory_pool_factory(|options: mountpoint_s3_client::config::MemoryPoolFactoryOptions| {
+        mountpoint_s3_fs::memory::PagedPool::new([options.part_size()])
+    });
+
     config
 }
 

--- a/mountpoint-s3-client/tests/common/mod.rs
+++ b/mountpoint-s3-client/tests/common/mod.rs
@@ -24,6 +24,7 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer};
 
 pub mod creds;
+pub mod memory_pool;
 pub mod tracing_test;
 
 /// Enable tracing and CRT logging when running unit tests.

--- a/mountpoint-s3-client/tests/endpoint_config.rs
+++ b/mountpoint-s3-client/tests/endpoint_config.rs
@@ -5,9 +5,9 @@ pub mod common;
 use aws_sdk_s3::primitives::ByteStream;
 use bytes::Bytes;
 use common::*;
+use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::{AddressingStyle, EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::types::GetObjectParams;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use test_case::test_case;
 
 async fn run_test(endpoint_config: EndpointConfig, prefix: &str, bucket: String) {
@@ -26,7 +26,7 @@ async fn run_test(endpoint_config: EndpointConfig, prefix: &str, bucket: String)
         .unwrap();
 
     let config = S3ClientConfig::new().endpoint_config(endpoint_config.clone());
-    let client = S3CrtClient::new(config).expect("could not create test client");
+    let client = get_test_client_with_config(config);
 
     let result = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -123,7 +123,7 @@ async fn test_single_region_access_point(addressing_style: AddressingStyle, arn:
 // For multi region access points, Rust SDK is not supported. Hence different helper method for these tests.
 async fn run_list_objects_test(endpoint_config: EndpointConfig, prefix: &str, bucket: &str) {
     let config = S3ClientConfig::new().endpoint_config(endpoint_config.clone());
-    let client = S3CrtClient::new(config).expect("could not create test client");
+    let client = get_test_client_with_config(config);
 
     client
         .list_objects(bucket, None, "/", 10, prefix)

--- a/mountpoint-s3-client/tests/get_object.rs
+++ b/mountpoint-s3-client/tests/get_object.rs
@@ -359,8 +359,7 @@ async fn test_get_object_wrong_region() {
     let key = format!("{prefix}/nonexistent_key");
 
     let endpoint_config = EndpointConfig::new(&get_secondary_test_region());
-    let client =
-        S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("must create a client");
+    let client = get_test_client_with_config(S3ClientConfig::new().endpoint_config(endpoint_config));
 
     let err = client
         .get_object(&bucket, &key, &GetObjectParams::new())
@@ -627,12 +626,11 @@ async fn stress_test_get_object() {
         .await
         .unwrap();
 
-    let client: S3CrtClient = S3CrtClient::new(
+    let client = get_test_client_with_config(
         S3ClientConfig::new()
             .endpoint_config(get_test_endpoint_config())
             .event_loop_threads(100),
-    )
-    .expect("could not create test client");
+    );
     assert!(client.read_part_size().unwrap() > size);
 
     let mut tasks = tokio::task::JoinSet::new();

--- a/mountpoint-s3-client/tests/head_bucket.rs
+++ b/mountpoint-s3-client/tests/head_bucket.rs
@@ -3,11 +3,7 @@
 pub mod common;
 
 use common::*;
-#[cfg(not(feature = "s3express_tests"))]
-use mountpoint_s3_client::S3CrtClient;
 use mountpoint_s3_client::S3RequestError;
-#[cfg(not(feature = "s3express_tests"))]
-use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
 use mountpoint_s3_client::error::{HeadBucketError, ObjectClientError};
 
 #[tokio::test]
@@ -21,10 +17,11 @@ async fn test_head_bucket_correct_region() {
 #[tokio::test]
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_head_bucket_wrong_region() {
+    use mountpoint_s3_client::config::{EndpointConfig, S3ClientConfig};
+
     let (bucket, _) = get_test_bucket_and_prefix("test_head_bucket_wrong_region");
     let endpoint_config = EndpointConfig::new(&get_secondary_test_region());
-    let client =
-        S3CrtClient::new(S3ClientConfig::new().endpoint_config(endpoint_config)).expect("could not create test client");
+    let client = get_test_client_with_config(S3ClientConfig::new().endpoint_config(endpoint_config));
     let expected_region = get_test_region();
 
     let result = client.head_bucket(&bucket).await;

--- a/mountpoint-s3-client/tests/network_interface_config.rs
+++ b/mountpoint-s3-client/tests/network_interface_config.rs
@@ -5,10 +5,10 @@ pub mod common;
 use test_case::test_case;
 
 use common::*;
+use mountpoint_s3_client::ObjectClient;
 use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{HeadObjectError, ObjectClientError::ServiceError};
 use mountpoint_s3_client::types::HeadObjectParams;
-use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 
 #[tokio::test]
 async fn test_empty_list() {
@@ -19,7 +19,7 @@ async fn test_empty_list() {
     let config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
-    let client = S3CrtClient::new(config).expect("client should create OK");
+    let client = create_client_with_config(config).expect("client should create OK");
 
     let err = client
         .head_object(&bucket, &key, &HeadObjectParams::new())
@@ -41,7 +41,7 @@ async fn test_one_interface_ok() {
     let config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
-    let client = S3CrtClient::new(config).expect("client should create OK");
+    let client = create_client_with_config(config).expect("client should create OK");
 
     let err = client
         .head_object(&bucket, &key, &HeadObjectParams::new())
@@ -68,7 +68,7 @@ async fn test_nonexistent(with_valid_interface: bool) {
     let config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .network_interface_names(interface_names);
-    S3CrtClient::new(config).expect_err(
+    create_client_with_config(config).expect_err(
         "CRT should return an error during client creation if provided with non-existent network interface",
     );
 }

--- a/mountpoint-s3-client/tests/put_object.rs
+++ b/mountpoint-s3-client/tests/put_object.rs
@@ -18,7 +18,7 @@ use mountpoint_s3_client::types::{
     ChecksumAlgorithm, GetObjectParams, HeadObjectParams, ObjectClientResult, PutObjectParams, PutObjectResult,
     PutObjectTrailingChecksums,
 };
-use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient, S3RequestError};
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3RequestError};
 
 // Simple test for PUT object. Puts a single, small object as a single part and checks that the
 // contents are correct with a GET.
@@ -315,10 +315,11 @@ async fn test_put_object_initiate_failure() {
 async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
     const PART_SIZE: usize = 5 * 1024 * 1024;
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_checksums");
-    let client_config = S3ClientConfig::new()
-        .part_size(PART_SIZE)
-        .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client_with_config(
+        S3ClientConfig::new()
+            .part_size(PART_SIZE)
+            .endpoint_config(get_test_endpoint_config()),
+    );
     let key = format!("{prefix}hello");
 
     let mut rng = rand::thread_rng();
@@ -384,8 +385,7 @@ async fn test_put_checksums(trailing_checksums: PutObjectTrailingChecksums) {
 #[tokio::test]
 async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_happy");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let key = format!("{prefix}hello");
 
     let params = PutObjectParams::new().object_metadata(object_metadata.clone());
@@ -415,8 +415,7 @@ async fn test_put_user_object_metadata_happy(object_metadata: HashMap<String, St
 #[tokio::test]
 async fn test_put_user_object_metadata_bad_header(object_metadata: HashMap<String, String>) {
     let (bucket, prefix) = get_test_bucket_and_prefix("test_put_user_object_metadata_bad_header");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let key = format!("{prefix}hello");
 
     let params = PutObjectParams::new().object_metadata(object_metadata.clone());
@@ -436,7 +435,7 @@ async fn test_put_review(pass_review: bool) {
     let client_config = S3ClientConfig::new()
         .part_size(PART_SIZE)
         .endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client_with_config(client_config);
     let key = format!("{prefix}hello");
 
     let mut rng = rand::thread_rng();
@@ -602,8 +601,7 @@ async fn check_sse(
 #[cfg(not(feature = "s3express_tests"))]
 async fn test_put_object_sse(sse_type: Option<&str>, kms_key_id: Option<String>) {
     let bucket = get_test_bucket();
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let request_params = PutObjectParams::new()
         .server_side_encryption(sse_type.map(|value| value.to_owned()))
         .ssekms_key_id(kms_key_id.to_owned());
@@ -639,7 +637,7 @@ async fn test_concurrent_put_objects(throughput_target_gbps: f64, max_concurrent
     let client_config = S3ClientConfig::new()
         .endpoint_config(get_test_endpoint_config())
         .throughput_target_gbps(throughput_target_gbps);
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client_with_config(client_config);
     let not_existing_key = format!("{prefix}not-there");
     let request_params = PutObjectParams::new();
 

--- a/mountpoint-s3-client/tests/rename_object.rs
+++ b/mountpoint-s3-client/tests/rename_object.rs
@@ -1,26 +1,24 @@
 #![cfg(feature = "s3express_tests")]
 
-use mountpoint_s3_client::config::S3ClientConfig;
 use mountpoint_s3_client::error::{ObjectClientError, RenameObjectError};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_client::types::{
     HeadObjectParams, PutObjectParams, PutObjectSingleParams, RenameObjectParams, RenamePreconditionTypes,
     UploadChecksum,
 };
-use mountpoint_s3_client::{ObjectClient, PutObjectRequest, S3CrtClient};
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
 use mountpoint_s3_crt::checksums::crc64nvme;
 use tracing::debug;
 use uuid::Uuid;
 
 pub mod common;
-use common::{get_test_bucket_and_prefix, get_test_endpoint_config};
+use common::{get_test_bucket_and_prefix, get_test_client};
 
 // Test that rename with source matching works as expected
 #[tokio::test]
 async fn simple_rename() {
     let (bucket, prefix) = get_test_bucket_and_prefix("put_append_rename_append_test");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -53,8 +51,7 @@ async fn simple_rename() {
 #[tokio::test]
 async fn put_append_rename_append_test() {
     let (bucket, prefix) = get_test_bucket_and_prefix("put_append_rename_append_test");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -110,8 +107,7 @@ async fn put_append_rename_append_test() {
 #[tokio::test]
 async fn rename_destination_does_not_match() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_destination_does_not_match");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -160,8 +156,7 @@ async fn rename_destination_does_not_match() {
 #[tokio::test]
 async fn rename_overwrite_error() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_overwrite_error");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -203,8 +198,7 @@ async fn rename_overwrite_error() {
 #[tokio::test]
 async fn rename_double_error() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_double_error");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -255,8 +249,7 @@ async fn rename_double_error() {
 #[tokio::test]
 async fn rename_source_does_not_match() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_source_does_not_match");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 
@@ -303,8 +296,7 @@ async fn rename_source_does_not_match() {
 #[tokio::test]
 async fn rename_idempotency_test() {
     let (bucket, prefix) = get_test_bucket_and_prefix("rename_idempotency_test");
-    let client_config = S3ClientConfig::new().endpoint_config(get_test_endpoint_config());
-    let client = S3CrtClient::new(client_config).expect("could not create test client");
+    let client = get_test_client();
     let source_key = format!("{prefix}a.txt");
     let dest_key = format!("{prefix}b.txt");
 

--- a/mountpoint-s3-crt/src/common/allocator.rs
+++ b/mountpoint-s3-crt/src/common/allocator.rs
@@ -83,3 +83,12 @@ impl Default for Allocator {
         Self { inner, traced: false }
     }
 }
+
+impl From<NonNull<aws_allocator>> for Allocator {
+    fn from(value: NonNull<aws_allocator>) -> Self {
+        Self {
+            inner: value,
+            traced: false,
+        }
+    }
+}

--- a/mountpoint-s3-crt/src/s3.rs
+++ b/mountpoint-s3-crt/src/s3.rs
@@ -11,6 +11,7 @@ use crate::common::allocator::Allocator;
 pub mod buffer;
 pub mod client;
 pub mod endpoint_resolver;
+pub mod pool;
 
 static S3_LIBRARY_INIT: Once = Once::new();
 

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -1,0 +1,429 @@
+//! Bridge custom memory pool implementations to the CRT S3 Client interface.
+
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{fmt::Debug, ptr::NonNull};
+
+use mountpoint_s3_crt_sys::{
+    aws_allocator, aws_byte_buf, aws_byte_buf_from_empty_array, aws_byte_cursor, aws_future_s3_buffer_ticket,
+    aws_future_s3_buffer_ticket_acquire, aws_future_s3_buffer_ticket_new, aws_future_s3_buffer_ticket_release,
+    aws_future_s3_buffer_ticket_set_result_by_move, aws_ref_count_init, aws_s3_buffer_pool, aws_s3_buffer_pool_config,
+    aws_s3_buffer_pool_factory_fn, aws_s3_buffer_pool_reserve_meta, aws_s3_buffer_pool_vtable, aws_s3_buffer_ticket,
+    aws_s3_buffer_ticket_vtable,
+};
+
+use crate::ToAwsByteCursor as _;
+use crate::common::allocator::Allocator;
+
+/// A custom memory pool.
+pub trait MemoryPool: Clone + Send + Sync {
+    /// Associated buffer type.
+    type Buffer: AsMut<[u8]>;
+
+    /// Get a buffer of at least the requested size.
+    fn get_buffer(&self, size: usize) -> Self::Buffer;
+
+    /// Trim the pool.
+    ///
+    /// Return `true` if the pool freed any memory.
+    fn trim(&self) -> bool;
+}
+
+/// Factory for a custom memory pool.
+pub trait MemoryPoolFactory {
+    /// The [MemoryPool] implementation created by this factory.
+    type Pool: MemoryPool;
+
+    /// Create a memory pool instance.
+    fn create(&self, options: MemoryPoolFactoryOptions) -> Self::Pool;
+}
+
+impl<F, P> MemoryPoolFactory for F
+where
+    F: Fn(MemoryPoolFactoryOptions) -> P,
+    P: MemoryPool,
+{
+    type Pool = P;
+
+    fn create(&self, options: MemoryPoolFactoryOptions) -> Self::Pool {
+        self(options)
+    }
+}
+
+/// Options to create a [MemoryPool].
+#[derive(Debug)]
+pub struct MemoryPoolFactoryOptions {
+    part_size: usize,
+    max_part_size: usize,
+    memory_limit: usize,
+}
+
+impl MemoryPoolFactoryOptions {
+    /// The default part size set on the client.
+    pub fn part_size(&self) -> usize {
+        self.part_size
+    }
+    /// The max part size for the client.
+    pub fn max_part_size(&self) -> usize {
+        self.max_part_size
+    }
+    /// The memory limit set on the client.
+    pub fn memory_limit(&self) -> usize {
+        self.memory_limit
+    }
+}
+
+/// Factory used by [Client](`super::client::Client`) to create CRT wrappers for [MemoryPool] implementations.
+#[derive(Debug, Clone)]
+pub struct CrtBufferPoolFactory(Arc<CrtBufferPoolFactoryInner>);
+
+#[derive(Debug)]
+struct CrtBufferPoolFactoryInner {
+    factory_ptr: NonNull<libc::c_void>,
+    factory_fn: aws_s3_buffer_pool_factory_fn,
+    drop_fn: fn(*mut ::libc::c_void),
+}
+
+// SAFETY: `CrtBufferPoolFactoryInner` is safe to transfer across threads because it wraps a [MemoryPoolFactory] implementation that is [Send].
+unsafe impl Send for CrtBufferPoolFactoryInner {}
+// SAFETY: `CrtBufferPoolFactoryInner` is safe to share across threads because it wraps a [MemoryPoolFactory] implementation that is [Sync].
+unsafe impl Sync for CrtBufferPoolFactoryInner {}
+
+impl Drop for CrtBufferPoolFactoryInner {
+    fn drop(&mut self) {
+        (self.drop_fn)(self.factory_ptr.as_ptr());
+    }
+}
+
+impl CrtBufferPoolFactory {
+    /// Builds a factory for the given pool.
+    pub fn new<PoolFactory: MemoryPoolFactory>(pool_factory: PoolFactory) -> Self {
+        let factory = Box::pin(pool_factory);
+        // SAFETY: The pointer to the factory will only be used in `buffer_pool_factory` and
+        // `drop_pool_factory`, which will treat it as pinned.
+        let leaked = Box::leak(unsafe { Pin::into_inner_unchecked(factory) });
+        // SAFETY: `leaked` is not null.
+        let factory_ptr = unsafe { NonNull::new_unchecked(leaked as *mut PoolFactory as *mut libc::c_void) };
+        Self(Arc::new(CrtBufferPoolFactoryInner {
+            factory_ptr,
+            factory_fn: Some(buffer_pool_factory::<PoolFactory>),
+            drop_fn: drop_pool_factory::<PoolFactory>,
+        }))
+    }
+
+    /// Returns the factory callback and user_data pointer to pass to the CRT.
+    pub(crate) fn as_inner(&self) -> (aws_s3_buffer_pool_factory_fn, *mut ::libc::c_void) {
+        (self.0.factory_fn, self.0.factory_ptr.as_ptr())
+    }
+}
+
+unsafe extern "C" fn buffer_pool_factory<PoolFactory: MemoryPoolFactory>(
+    allocator: *mut aws_allocator,
+    config: aws_s3_buffer_pool_config,
+    user_data: *mut libc::c_void,
+) -> *mut aws_s3_buffer_pool {
+    // SAFETY: `user_data` references a `Box` owned by the `CrtBufferPoolFactory` instance.
+    let pool_factory = unsafe { &*(user_data as *mut PoolFactory) };
+
+    // SAFETY: `allocator` is a non-null pointer to a `aws_allocator` instance.
+    let allocator = unsafe { NonNull::new_unchecked(allocator).into() };
+
+    let options = MemoryPoolFactoryOptions {
+        part_size: config.part_size,
+        max_part_size: config.max_part_size,
+        memory_limit: config.memory_limit,
+    };
+    let pool = pool_factory.create(options);
+
+    let crt_pool = CrtBufferPool::new(pool.clone(), allocator);
+
+    // SAFETY: the CRT will only use the pool through its vtable and refcount.
+    unsafe { crt_pool.leak() }
+}
+
+fn drop_pool_factory<PoolFactory: MemoryPoolFactory>(factory_ptr: *mut libc::c_void) {
+    // SAFETY: `factory_ptr` was leaked in `CrtBufferPoolFactory::new`.
+    _ = unsafe { Pin::new_unchecked(Box::from_raw(factory_ptr as *mut PoolFactory)) };
+}
+
+/// Internal wrapper to bridge the [MemoryPool] implementation to
+/// the `aws_s3_buffer_pool` to provide to the CRT.
+///
+/// Instances of this type also hold the vtables to set up both
+/// the `aws_s3_buffer_pool` itself and the `aws_s3_buffer_ticket`s
+/// it returns. Notably, all the functions in the vtables are generic
+/// in the same [MemoryPool] implementation as [CrtBufferPool], so
+/// that the CRT can handle different implementations and there is
+/// no need for dynamic dispatch on the Rust side.
+struct CrtBufferPool<Pool: MemoryPool> {
+    /// Inner struct to pass to CRT functions.
+    inner: aws_s3_buffer_pool,
+    /// [MemoryPool] implementation.
+    pool: Pool,
+    /// Holds the vtable to point to in `inner`.
+    pool_vtable: aws_s3_buffer_pool_vtable,
+    /// Holds the vtable for the `aws_s3_buffer_ticket` instances.
+    ticket_vtable: aws_s3_buffer_ticket_vtable,
+    /// CRT allocator.
+    allocator: Allocator,
+    /// Pin this struct because inner.impl_ will be a pointer to this object.
+    _pinned: PhantomPinned,
+}
+
+impl<Pool: MemoryPool> CrtBufferPool<Pool> {
+    fn new(pool: Pool, allocator: Allocator) -> Pin<Box<Self>> {
+        // `inner` will be initialized after pinning because its fields require pinned addresses.
+        let mut crt_pool = Box::pin(CrtBufferPool {
+            inner: Default::default(),
+            pool,
+            pool_vtable: aws_s3_buffer_pool_vtable {
+                reserve: Some(pool_reserve::<Pool>),
+                trim: Some(pool_trim::<Pool>),
+                acquire: None,
+                release: None,
+            },
+            ticket_vtable: aws_s3_buffer_ticket_vtable {
+                claim: Some(ticket_claim::<Pool::Buffer>),
+                acquire: None,
+                release: None,
+            },
+            allocator,
+            _pinned: Default::default(),
+        });
+
+        // Set up the vtable and `impl_` to the pinned addresses (self-referential) and initialize ref-counting.
+        // SAFETY: We're setting up the struct to be self-referential, and we're not moving out
+        // of the struct, so the unchecked deref of the pinned pointer is okay.
+        unsafe {
+            let pool_ref = Pin::get_unchecked_mut(Pin::as_mut(&mut crt_pool));
+            pool_ref.inner.vtable = &raw mut pool_ref.pool_vtable;
+            pool_ref.inner.impl_ = pool_ref as *mut CrtBufferPool<Pool> as *mut libc::c_void;
+            aws_ref_count_init(
+                &mut pool_ref.inner.ref_count,
+                &mut pool_ref.inner as *mut aws_s3_buffer_pool as *mut libc::c_void,
+                Some(pool_destroy::<Pool>),
+            );
+        }
+
+        crt_pool
+    }
+
+    /// Leak a pinned instance and returns a raw pointer.
+    ///
+    /// # Safety
+    /// The returned pointer must eventually be passed to [from_raw] and can
+    /// additionally only used in [ref_from_raw].
+    unsafe fn leak(self: Pin<Box<Self>>) -> *mut aws_s3_buffer_pool {
+        // SAFETY: the resulting pointer will be only used in `pool_reserve`, `pool_trim`, and `pool_destroy`.
+        let pool = Box::leak(unsafe { Pin::into_inner_unchecked(self) });
+        &raw mut pool.inner
+    }
+
+    /// Returns a reference to original instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn ref_from_raw(pool: &*mut aws_s3_buffer_pool) -> &Self {
+        // SAFETY: `pool` points to the `inner` field of a pinned instance.
+        unsafe {
+            let impl_ptr = (**pool).impl_;
+            &*(impl_ptr as *mut Self)
+        }
+    }
+
+    /// Re-constructs the original pinned instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn from_raw(pool: *mut aws_s3_buffer_pool) -> Pin<Box<Self>> {
+        // SAFETY: `pool` points to the `inner` field of a pinned instance.
+        unsafe { Pin::new_unchecked(Box::from_raw((*pool).impl_ as *mut Self)) }
+    }
+
+    fn trim(&self) {
+        self.pool.trim();
+    }
+
+    fn reserve(&self, size: usize) -> CrtTicketFuture {
+        let future = CrtTicketFuture::new(&self.allocator);
+
+        // Get a buffer from the pool, build its ticket, and immediately fullfil the future.
+        // This will likely change later, when we make the method on the pool async.
+        let buffer = self.pool.get_buffer(size);
+        let ticket = self.make_ticket(buffer);
+        future.set(ticket);
+
+        future
+    }
+
+    fn make_ticket(&self, buffer: Pool::Buffer) -> Pin<Box<CrtTicket<Pool::Buffer>>> {
+        // Set up the vtable by pointing into the pool pinned address, but leave `impl_`
+        // and `ref_count` to be initialized after pinning the ticket.
+        let mut ticket = Box::pin(CrtTicket {
+            inner: aws_s3_buffer_ticket {
+                vtable: (&raw const self.ticket_vtable).cast_mut(),
+                ref_count: Default::default(),
+                impl_: std::ptr::null_mut(),
+            },
+            buffer,
+            _pinned: Default::default(),
+        });
+
+        // Set `impl_` to the pinned address (self-referential) and initialize ref-counting.
+        // SAFETY: We're setting up the struct to be self-referential, and we're not moving out
+        // of the struct, so the unchecked deref of the pinned pointer is okay.
+        unsafe {
+            let ticket_ref = Pin::get_unchecked_mut(Pin::as_mut(&mut ticket));
+            ticket_ref.inner.impl_ = ticket_ref as *mut CrtTicket<Pool::Buffer> as *mut libc::c_void;
+            aws_ref_count_init(
+                &mut ticket_ref.inner.ref_count,
+                &mut ticket_ref.inner as *mut aws_s3_buffer_ticket as *mut libc::c_void,
+                Some(ticket_destroy::<Pool::Buffer>),
+            );
+        }
+
+        ticket
+    }
+}
+
+unsafe extern "C" fn pool_reserve<Pool: MemoryPool>(
+    pool: *mut aws_s3_buffer_pool,
+    meta: aws_s3_buffer_pool_reserve_meta,
+) -> *mut aws_future_s3_buffer_ticket {
+    // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
+    let crt_pool = unsafe { CrtBufferPool::<Pool>::ref_from_raw(&pool) };
+    let future = crt_pool.reserve(meta.size);
+
+    // SAFETY: the CRT will take ownership of the future.
+    unsafe { future.into_inner_ptr() }
+}
+
+unsafe extern "C" fn pool_trim<Pool: MemoryPool>(pool: *mut aws_s3_buffer_pool) {
+    // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
+    let crt_pool = unsafe { CrtBufferPool::<Pool>::ref_from_raw(&pool) };
+    crt_pool.trim();
+}
+
+unsafe extern "C" fn pool_destroy<Pool: MemoryPool>(data: *mut libc::c_void) {
+    let pool = data as *mut aws_s3_buffer_pool;
+
+    // SAFETY: `pool` was obtained through `CrtMemoryPool::leak`.
+    _ = unsafe { CrtBufferPool::<Pool>::from_raw(pool) };
+}
+
+/// Wrapper for [aws_s3_buffer_ticket].
+struct CrtTicket<Buffer: AsMut<[u8]>> {
+    /// Inner struct to pass to CRT functions.
+    inner: aws_s3_buffer_ticket,
+    /// Buffer implementing [AsMut<\[u8\]>].
+    buffer: Buffer,
+    /// Pin this struct because inner.impl_ will be a pointer to this object.
+    _pinned: PhantomPinned,
+}
+
+impl<Buffer: AsMut<[u8]>> CrtTicket<Buffer> {
+    /// Leak a pinned instance and returns a raw pointer.
+    ///
+    /// # Safety
+    /// The returned pointer must eventually be passed to [from_raw] and can
+    /// additionally only used in [ref_mut_from_raw].
+    unsafe fn leak(self: Pin<Box<Self>>) -> *mut aws_s3_buffer_ticket {
+        // SAFETY: the resulting pointer will be only used in `ticket_claim` and `ticket_destroy`.
+        let boxed = unsafe { Pin::into_inner_unchecked(self) };
+        let pool = Box::leak(boxed);
+        &raw mut pool.inner
+    }
+
+    /// Returns a reference to original instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn ref_mut_from_raw(ticket: &mut *mut aws_s3_buffer_ticket) -> &mut Self {
+        // SAFETY: `ticket` points to the `inner` field of a pinned instance.
+        unsafe {
+            let impl_ptr = (**ticket).impl_;
+            &mut *(impl_ptr as *mut Self)
+        }
+    }
+
+    /// Re-constructs the original pinned instance from a raw pointer.
+    ///
+    /// # Safety
+    /// The raw pointer must have been obtained through [leak()].
+    unsafe fn from_raw(ticket: *mut aws_s3_buffer_ticket) -> Pin<Box<Self>> {
+        // SAFETY: `ticket` points to the `inner` field of a pinned instance.
+        unsafe { Pin::new_unchecked(Box::from_raw((*ticket).impl_ as *mut Self)) }
+    }
+}
+
+unsafe extern "C" fn ticket_claim<Buffer: AsMut<[u8]>>(mut ticket: *mut aws_s3_buffer_ticket) -> aws_byte_buf {
+    // SAFETY: `ticket` was obtained through `Ticket::leak`.
+    let ticket = unsafe { CrtTicket::<Buffer>::ref_mut_from_raw(&mut ticket) };
+
+    // SAFETY: the CRT guarantees to only use the returned buffer while holding the ticket.
+    let aws_byte_cursor { len, ptr } = unsafe { ticket.buffer.as_mut().as_aws_byte_cursor() };
+
+    // SAFETY: `ptr` is a valid buffer with capacity >= `size`.
+    unsafe { aws_byte_buf_from_empty_array(ptr as *mut libc::c_void, len) }
+}
+
+unsafe extern "C" fn ticket_destroy<Buffer: AsMut<[u8]>>(data: *mut libc::c_void) {
+    let ticket = data as *mut aws_s3_buffer_ticket;
+    // SAFETY: `ticket` was obtained through `Ticket::leak`.
+    _ = unsafe { CrtTicket::<Buffer>::from_raw(ticket) };
+}
+
+/// Wrapper for [aws_future_s3_buffer_ticket].
+#[derive(Debug)]
+struct CrtTicketFuture {
+    inner: *mut aws_future_s3_buffer_ticket,
+}
+
+// SAFETY: `aws_future_s3_buffer_ticket` is reference counted and its methods are thread-safe
+unsafe impl Send for CrtTicketFuture {}
+
+// SAFETY: `aws_future_s3_buffer_ticket` is reference counted and its methods are thread-safe
+unsafe impl Sync for CrtTicketFuture {}
+
+impl CrtTicketFuture {
+    fn new(allocator: &Allocator) -> Self {
+        // SAFETY: aws_future_s3_buffer_ticket_new return a non-null pointer to a new aws_future_s3_buffer_ticket with a reference count of 1.
+        let inner = unsafe { aws_future_s3_buffer_ticket_new(allocator.inner.as_ptr()) };
+        Self { inner }
+    }
+
+    fn set<Buffer: AsMut<[u8]>>(&self, ticket: Pin<Box<CrtTicket<Buffer>>>) {
+        // SAFETY: `ticket` will be passed to the CRT which will only use it through its vtable and refcount.
+        let mut ticket = unsafe { ticket.leak() };
+        // SAFETY: `self.inner` is a valid future and we are setting it to `ticket`.
+        unsafe {
+            aws_future_s3_buffer_ticket_set_result_by_move(self.inner, &mut ticket);
+        }
+    }
+
+    /// Return the pointer to the inner `aws_future_s3_buffer_ticket` instance.
+    ///
+    /// # Safety
+    /// The returned pointer follows ref-counting rules and must be eventually released.
+    unsafe fn into_inner_ptr(mut self) -> *mut aws_future_s3_buffer_ticket {
+        std::mem::replace(&mut self.inner, std::ptr::null_mut())
+    }
+}
+
+impl Clone for CrtTicketFuture {
+    fn clone(&self) -> Self {
+        // SAFETY: `self.inner` is a valid `aws_future_s3_buffer_ticket`, and we increment its
+        // reference count on Clone and decrement it on Drop.
+        let inner = unsafe { aws_future_s3_buffer_ticket_acquire(self.inner) };
+        Self { inner }
+    }
+}
+
+impl Drop for CrtTicketFuture {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` is a valid `aws_future_s3_buffer_ticket`, and on Drop it's safe to decrement
+        // the reference count since this is balancing the `acquire` in `new`.
+        unsafe { aws_future_s3_buffer_ticket_release(self.inner) };
+    }
+}

--- a/mountpoint-s3-crt/src/s3/pool.rs
+++ b/mountpoint-s3-crt/src/s3/pool.rs
@@ -31,7 +31,7 @@ pub trait MemoryPool: Clone + Send + Sync {
 }
 
 /// Factory for a custom memory pool.
-pub trait MemoryPoolFactory {
+pub trait MemoryPoolFactory: Send + Sync {
     /// The [MemoryPool] implementation created by this factory.
     type Pool: MemoryPool;
 
@@ -41,7 +41,7 @@ pub trait MemoryPoolFactory {
 
 impl<F, P> MemoryPoolFactory for F
 where
-    F: Fn(MemoryPoolFactoryOptions) -> P,
+    F: Fn(MemoryPoolFactoryOptions) -> P + Send + Sync,
     P: MemoryPool,
 {
     type Pool = P;

--- a/mountpoint-s3-fs/Cargo.toml
+++ b/mountpoint-s3-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Mountpoint S3 main library"
 
 [dependencies]
 mountpoint-s3-fuser = { path = "../mountpoint-s3-fuser", version = "0.1.0", features = ["abi-7-28"] }
-mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.18.0", features = ["restore_buffer_copy"] }
+mountpoint-s3-client = { path = "../mountpoint-s3-client", version = "0.18.0" }
 
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 async-channel = "2.3.1"

--- a/mountpoint-s3-fs/src/lib.rs
+++ b/mountpoint-s3-fs/src/lib.rs
@@ -9,6 +9,7 @@ pub mod logging;
 #[cfg(feature = "manifest")]
 pub mod manifest;
 pub mod mem_limiter;
+pub mod memory;
 pub mod metablock;
 pub mod metrics;
 pub mod object;

--- a/mountpoint-s3-fs/src/memory.rs
+++ b/mountpoint-s3-fs/src/memory.rs
@@ -1,0 +1,499 @@
+use std::alloc::{self, Layout, handle_alloc_error};
+use std::io::Read;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+use bytes::Bytes;
+use mountpoint_s3_client::config::MemoryPool;
+
+/// A memory pool implementation that uses paged buffers.
+#[derive(Debug, Clone)]
+pub struct PagedPool {
+    inner: Arc<PagedPoolInner>,
+}
+
+impl PagedPool {
+    /// Creates a pool that reuses buffers of the given sizes.
+    pub fn new(buffer_sizes: impl Into<Vec<usize>>) -> Self {
+        let mut buffer_sizes: Vec<_> = buffer_sizes.into();
+        buffer_sizes.sort();
+        buffer_sizes.dedup();
+
+        let size_pools = buffer_sizes
+            .iter()
+            .map(|&buffer_size| SizePool {
+                pages: Default::default(),
+                stats: Arc::new(SizePoolStats::new(buffer_size)),
+            })
+            .collect();
+
+        let inner = PagedPoolInner { size_pools };
+        Self { inner: Arc::new(inner) }
+    }
+
+    /// Trim empty pages in the pool.
+    pub fn trim(&self) -> bool {
+        self.inner.trim()
+    }
+
+    /// Schedule recurring calls to [trim()](Self::trim()).
+    pub fn schedule_trim(&self, recurring_time: Duration) {
+        let weak = Arc::downgrade(&self.inner);
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(recurring_time);
+                let Some(pool) = weak.upgrade() else {
+                    return;
+                };
+                pool.trim();
+            }
+        });
+    }
+
+    /// Reads `size` bytes into a new buffer from the pool.
+    pub fn read_exact(&self, read: &mut impl Read, size: usize) -> std::io::Result<Bytes> {
+        let mut buffer = self.get_buffer(size);
+        read.read_exact(buffer.as_mut())?;
+        Ok(Bytes::from_owner(buffer))
+    }
+
+    fn get_buffer(&self, size: usize) -> PoolBuffer {
+        PoolBuffer(match self.reserve(size) {
+            Some(buffer_ptr) => {
+                metrics::histogram!("pool.reserve", "type" => "primary").record(size as f64);
+                PoolBufferInner::Primary { buffer_ptr, size }
+            }
+            None => {
+                metrics::histogram!("pool.reserve", "type" => "secondary").record(size as f64);
+                PoolBufferInner::Secondary(vec![0u8; size].into_boxed_slice())
+            }
+        })
+    }
+
+    fn reserve(&self, size: usize) -> Option<PagedBufferPtr> {
+        let pool = self.inner.get_pool_for_size(size)?;
+        pool.reserve()
+    }
+
+    #[cfg(test)]
+    fn page_count(&self) -> usize {
+        self.inner
+            .size_pools
+            .iter()
+            .map(|pool| pool.pages.read().unwrap().len())
+            .sum()
+    }
+
+    #[cfg(test)]
+    fn used_buffer_count(&self) -> usize {
+        self.inner.size_pools.iter().map(|pool| pool.stats.used_buffers()).sum()
+    }
+
+    #[cfg(test)]
+    fn copy_from_slice(&self, original: &[u8]) -> Bytes {
+        use bytes::Buf as _;
+
+        self.read_exact(&mut original.reader(), original.len())
+            .expect("read from slice should succeed")
+    }
+}
+
+impl MemoryPool for PagedPool {
+    type Buffer = PoolBuffer;
+
+    fn get_buffer(&self, size: usize) -> Self::Buffer {
+        self.get_buffer(size)
+    }
+
+    fn trim(&self) -> bool {
+        self.trim()
+    }
+}
+
+#[derive(Debug)]
+struct PagedPoolInner {
+    size_pools: Vec<SizePool>,
+}
+
+impl PagedPoolInner {
+    fn get_pool_for_size(&self, size: usize) -> Option<&SizePool> {
+        if size == 0 {
+            return None;
+        }
+
+        let index = self.size_pools.partition_point(|p| p.stats.buffer_size < size);
+        if index == self.size_pools.len() {
+            return None;
+        }
+
+        Some(&self.size_pools[index])
+    }
+
+    fn trim(&self) -> bool {
+        let mut removed = false;
+        for pool in &self.size_pools {
+            if pool.stats.empty_pages() == 0 {
+                continue;
+            }
+            let mut write = pool.pages.write().unwrap();
+            let len = write.len();
+            write.retain(|p| !p.invalidate());
+
+            let pages_freed = len - write.len();
+            if pages_freed > 0 {
+                tracing::trace!(
+                    size = pool.stats.buffer_size,
+                    pages_freed,
+                    "free empty memory pool pages"
+                );
+                removed = true;
+            }
+            metrics::histogram!("pool.trim", "size" => format!("{}", pool.stats.buffer_size))
+                .record(pages_freed as f64);
+        }
+
+        removed
+    }
+}
+
+/// Pool buffer.
+#[derive(Debug)]
+pub struct PoolBuffer(PoolBufferInner);
+
+#[derive(Debug)]
+enum PoolBufferInner {
+    /// Buffer from the paged pool.
+    Primary { buffer_ptr: PagedBufferPtr, size: usize },
+    /// Buffer allocated independently.
+    Secondary(Box<[u8]>),
+}
+
+impl AsMut<[u8]> for PoolBuffer {
+    fn as_mut(&mut self) -> &mut [u8] {
+        match &mut self.0 {
+            PoolBufferInner::Primary { buffer_ptr, size } => {
+                // SAFETY: returned slice will be valid until this buffer is dropped.
+                unsafe { std::slice::from_raw_parts_mut(buffer_ptr.ptr, *size) }
+            }
+            PoolBufferInner::Secondary(boxed) => boxed,
+        }
+    }
+}
+
+impl AsRef<[u8]> for PoolBuffer {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            PoolBufferInner::Primary { buffer_ptr, size } => {
+                // SAFETY: returned slice will be valid until this buffer is dropped.
+                unsafe { std::slice::from_raw_parts(buffer_ptr.ptr, *size) }
+            }
+            PoolBufferInner::Secondary(boxed) => boxed,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PagedBufferPtr {
+    ptr: *mut u8,
+    pool_page: Page,
+}
+
+// SAFETY: access to the buffer and release back to the pool page on drop can be performed from another thread.
+unsafe impl Send for PagedBufferPtr {}
+
+impl Drop for PagedBufferPtr {
+    fn drop(&mut self) {
+        self.pool_page.release(self.ptr);
+    }
+}
+
+#[derive(Debug)]
+struct SizePool {
+    pages: RwLock<Vec<Page>>,
+    stats: Arc<SizePoolStats>,
+}
+
+impl SizePool {
+    fn reserve(&self) -> Option<PagedBufferPtr> {
+        {
+            let read_pages = self.pages.read().unwrap();
+            if let Some(buffer_ptr) = self.try_get_buffer_ptr(read_pages.iter()) {
+                return Some(buffer_ptr);
+            }
+        }
+
+        let mut write_pages = self.pages.write().unwrap();
+        if let Some(buffer_ptr) = self.try_get_buffer_ptr(write_pages.iter()) {
+            return Some(buffer_ptr);
+        }
+
+        tracing::trace!(size = self.stats.buffer_size, "allocate new memory pool page");
+        let page = Page::new(self.stats.clone());
+        let buffer_ptr = page.try_reserve().unwrap();
+        write_pages.push(page);
+        Some(buffer_ptr)
+    }
+
+    fn try_get_buffer_ptr<'a>(&self, mut pages: impl Iterator<Item = &'a Page>) -> Option<PagedBufferPtr> {
+        pages.find_map(|page| page.try_reserve())
+    }
+}
+
+#[derive(Debug)]
+struct SizePoolStats {
+    buffer_size: usize,
+    empty_pages: AtomicUsize,
+    used_buffers: AtomicUsize,
+}
+
+impl SizePoolStats {
+    fn new(buffer_size: usize) -> Self {
+        Self {
+            buffer_size,
+            empty_pages: Default::default(),
+            used_buffers: Default::default(),
+        }
+    }
+
+    fn empty_pages(&self) -> usize {
+        self.empty_pages.load(Ordering::SeqCst)
+    }
+
+    fn add_empty_page(&self) {
+        self.empty_pages.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn remove_empty_page(&self) {
+        self.empty_pages.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn used_buffers(&self) -> usize {
+        self.used_buffers.load(Ordering::SeqCst)
+    }
+
+    fn add_used_buffer(&self) {
+        self.used_buffers.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn remove_used_buffer(&self) {
+        self.used_buffers.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Page {
+    inner: Arc<PageInner>,
+}
+
+#[derive(Debug)]
+struct PageInner {
+    bytes: *mut u8,
+    last_offset: *mut u8,
+    free_bitmask: Mutex<u16>,
+    layout: Layout,
+    stats: Arc<SizePoolStats>,
+}
+
+// SAFETY: access to mutable state in `PageInner` is synchonized internally.
+unsafe impl Send for PageInner {}
+
+// SAFETY: access to mutable state in `PageInner` is synchonized internally.
+unsafe impl Sync for PageInner {}
+
+impl Drop for PageInner {
+    fn drop(&mut self) {
+        // SAFETY: `self.bytes` was allocated using `self.layout` in `Page::new`.
+        unsafe {
+            alloc::dealloc(self.bytes, self.layout);
+        }
+    }
+}
+
+impl Page {
+    const BUFFERS_PER_PAGE: usize = 16;
+
+    fn new(stats: Arc<SizePoolStats>) -> Self {
+        assert_ne!(stats.buffer_size, 0);
+        let layout = Layout::array::<[u8; Self::BUFFERS_PER_PAGE]>(stats.buffer_size).unwrap();
+
+        // SAFETY: layout has non-zero size.
+        let bytes = unsafe { alloc::alloc(layout) };
+        if bytes.is_null() {
+            handle_alloc_error(layout);
+        }
+
+        stats.add_empty_page();
+
+        // SAFETY: last_offset is guaranteed to belong to the allocated object.
+        let last_offset = unsafe { bytes.add((Self::BUFFERS_PER_PAGE - 1) * stats.buffer_size) };
+        let inner = PageInner {
+            bytes,
+            last_offset,
+            free_bitmask: Default::default(),
+            layout,
+            stats,
+        };
+        Page { inner: Arc::new(inner) }
+    }
+
+    fn try_reserve(&self) -> Option<PagedBufferPtr> {
+        let (index, page_status) = consume(&mut self.inner.free_bitmask.lock().unwrap())?;
+        let offset = index * self.inner.stats.buffer_size;
+        if let PageStatus::Empty = page_status {
+            self.inner.stats.remove_empty_page();
+        };
+
+        self.inner.stats.add_used_buffer();
+
+        // SAFETY: ptr is in bounds of the allocated object, since offset < page_size.
+        let ptr = unsafe { self.inner.bytes.add(offset) };
+        Some(PagedBufferPtr {
+            ptr,
+            pool_page: self.clone(),
+        })
+    }
+
+    fn release(&self, ptr: *mut u8) {
+        assert!(
+            ptr >= self.inner.bytes && ptr <= self.inner.last_offset,
+            "the pointer does not belong to this page"
+        );
+
+        // SAFETY: ptr points to the same allocated object as self.inner.bytes.
+        let offset = unsafe { ptr.offset_from(self.inner.bytes) };
+        let index = offset as usize / self.inner.stats.buffer_size;
+        let mask = !(1u16 << index);
+        self.inner.stats.remove_used_buffer();
+        let mut bitmask = self.inner.free_bitmask.lock().unwrap();
+        *bitmask &= mask;
+        if *bitmask == 0 {
+            self.inner.stats.add_empty_page();
+        }
+    }
+
+    fn invalidate(&self) -> bool {
+        let mut bitmask = self.inner.free_bitmask.lock().unwrap();
+        if *bitmask != 0 {
+            return false;
+        }
+        // Prevent further use.
+        *bitmask = FULL_MASK;
+        true
+    }
+}
+
+const FULL_MASK: u16 = 0xFFFF;
+
+fn consume(bitmask: &mut u16) -> Option<(usize, PageStatus)> {
+    if *bitmask != FULL_MASK {
+        let page_status = if *bitmask == 0 {
+            PageStatus::Empty
+        } else {
+            PageStatus::NonEmpty
+        };
+        for index in 0usize..16 {
+            let mask = 1u16 << index;
+            if *bitmask & mask == 0 {
+                *bitmask |= mask;
+                return Some((index, page_status));
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug)]
+enum PageStatus {
+    Empty,
+    NonEmpty,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+    use std::thread::{self, sleep};
+    use std::time::Duration;
+
+    use super::*;
+
+    use rand::Rng;
+    use test_case::{test_case, test_matrix};
+
+    #[test_case(&[1, 2, 3], &[5, 10])]
+    #[test_case(&vec![42u8; 1000], &[128, 1024])]
+    fn test_from_slice(original: &[u8], buffer_sizes: &[usize]) {
+        let pool = PagedPool::new(buffer_sizes);
+        let bytes = pool.copy_from_slice(original);
+        assert_eq!(original, bytes.deref());
+    }
+
+    #[test_case(&[5, 10, 1024])]
+    fn test_pages(buffer_sizes: &[usize]) {
+        let pool = PagedPool::new(buffer_sizes);
+
+        for &size in buffer_sizes {
+            let original = vec![1u8; size];
+
+            assert_eq!(pool.page_count(), 0);
+            assert_eq!(pool.used_buffer_count(), 0);
+
+            let mut buffers = Vec::new();
+            for _ in 0..16 {
+                buffers.push(pool.copy_from_slice(&original));
+            }
+            assert_eq!(pool.page_count(), 1);
+            assert_eq!(pool.used_buffer_count(), 16);
+
+            buffers.push(pool.copy_from_slice(&original));
+            assert_eq!(pool.page_count(), 2);
+            assert_eq!(pool.used_buffer_count(), 17);
+
+            assert!(!pool.trim());
+
+            drop(buffers);
+
+            assert_eq!(pool.page_count(), 2);
+            assert_eq!(pool.used_buffer_count(), 0);
+
+            assert!(pool.trim());
+            assert_eq!(pool.page_count(), 0);
+            assert_eq!(pool.used_buffer_count(), 0);
+        }
+    }
+
+    #[test_matrix(&[1, 2, 3, 4, 5, 6, 7], &[5, 10], [None, Some(Duration::from_millis(1))])]
+    #[test_matrix(&vec![42u8; 1000], &[128, 1024], [None, Some(Duration::from_millis(10))])]
+    #[test_matrix(&vec![42u8; 10000], &[128, 1024, 2024, 8192], [None, Some(Duration::from_millis(10))])]
+    fn stress_test(original: &[u8], buffer_sizes: &[usize], schedule: Option<Duration>) {
+        let pool = PagedPool::new(buffer_sizes);
+        if let Some(duration) = schedule {
+            pool.schedule_trim(duration);
+        }
+
+        let num_threads = 10000;
+        thread::scope(|scope| {
+            for i in 0..num_threads {
+                let pool = pool.clone();
+                scope.spawn(move || {
+                    let len = rand::thread_rng().gen_range(1..original.len());
+                    let original = &original[..len];
+                    let bytes = pool.copy_from_slice(&original[..len]);
+                    assert_eq!(original, bytes.deref());
+
+                    sleep(Duration::from_millis(i as u64 % 10));
+
+                    let bytes = pool.copy_from_slice(&bytes);
+                    assert_eq!(original, bytes.deref());
+                });
+            }
+        });
+
+        let page_count = pool.page_count();
+        if page_count > 0 {
+            pool.trim();
+            assert_eq!(pool.page_count(), 0);
+        }
+    }
+}

--- a/mountpoint-s3/src/bin/mock-mount-s3.rs
+++ b/mountpoint-s3/src/bin/mock-mount-s3.rs
@@ -19,6 +19,7 @@ use mountpoint_s3_client::mock_client::throughput_client::ThroughputMockClient;
 use mountpoint_s3_client::mock_client::{MockClient, MockObject};
 use mountpoint_s3_client::types::ETag;
 use mountpoint_s3_fs::Runtime;
+use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::s3::S3Personality;
 use mountpoint_s3_fs::s3::config::{ClientConfig, S3Path, TargetThroughputSetting};
 
@@ -29,6 +30,7 @@ fn main() -> anyhow::Result<()> {
 
 pub fn create_mock_client(
     client_config: ClientConfig,
+    _pool: PagedPool,
     s3_path: &S3Path,
     personality: Option<S3Personality>,
 ) -> anyhow::Result<(Arc<ThroughputMockClient>, Runtime, S3Personality)> {

--- a/mountpoint-s3/src/run.rs
+++ b/mountpoint-s3/src/run.rs
@@ -10,6 +10,7 @@ use mountpoint_s3_client::{ObjectClient, S3CrtClient};
 use mountpoint_s3_fs::data_cache::{DataCacheConfig, ManagedCacheDir};
 use mountpoint_s3_fs::fuse::session::FuseSession;
 use mountpoint_s3_fs::logging::init_logging;
+use mountpoint_s3_fs::memory::PagedPool;
 use mountpoint_s3_fs::s3::S3Personality;
 use mountpoint_s3_fs::s3::config::{ClientConfig, S3Path};
 use mountpoint_s3_fs::{MountpointConfig, Runtime, metrics};
@@ -174,8 +175,17 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
 
     let client_config = args.client_config(build_info::FULL_VERSION);
 
+    // Set up a paged memory pool
+    let pool = PagedPool::new([
+        1024 * 1024,
+        client_config.part_config.read_size_bytes,
+        client_config.part_config.write_size_bytes,
+    ]);
+    pool.schedule_trim(Duration::from_secs(60));
+
     let s3_path = args.s3_path()?;
-    let (client, runtime, s3_personality) = client_builder.build(client_config, &s3_path, args.personality())?;
+    let (client, runtime, s3_personality) =
+        client_builder.build(client_config, pool.clone(), &s3_path, args.personality())?;
 
     let bucket_description = args.bucket_description()?;
     tracing::debug!("using S3 personality {s3_personality:?} for {bucket_description}");
@@ -189,7 +199,7 @@ fn mount(args: CliArgs, client_builder: impl ClientBuilder) -> anyhow::Result<Fu
     let mount_point_path = format!("{}", fuse_session_config.mount_point());
 
     let mut fuse_session = MountpointConfig::new(fuse_session_config, filesystem_config, data_cache_config)
-        .create_fuse_session(s3_path, client, runtime)?;
+        .create_fuse_session(s3_path, client, runtime, Some(pool))?;
     tracing::info!("successfully mounted {} at {}", bucket_description, mount_point_path);
 
     if let Some(managed_cache_dir) = managed_cache_dir {
@@ -208,6 +218,7 @@ pub trait ClientBuilder {
     fn build(
         self,
         client_config: ClientConfig,
+        pool: PagedPool,
         s3_path: &S3Path,
         personality: Option<S3Personality>,
     ) -> anyhow::Result<(Self::Client, Runtime, S3Personality)>;
@@ -215,7 +226,7 @@ pub trait ClientBuilder {
 
 impl<F, C> ClientBuilder for F
 where
-    F: FnOnce(ClientConfig, &S3Path, Option<S3Personality>) -> anyhow::Result<(C, Runtime, S3Personality)>,
+    F: FnOnce(ClientConfig, PagedPool, &S3Path, Option<S3Personality>) -> anyhow::Result<(C, Runtime, S3Personality)>,
     C: ObjectClient + Clone + Send + Sync + 'static,
 {
     type Client = C;
@@ -223,21 +234,23 @@ where
     fn build(
         self,
         client_config: ClientConfig,
+        pool: PagedPool,
         s3_path: &S3Path,
         personality: Option<S3Personality>,
     ) -> anyhow::Result<(Self::Client, Runtime, S3Personality)> {
-        self(client_config, s3_path, personality)
+        self(client_config, pool, s3_path, personality)
     }
 }
 
 // Create a real S3 client
 pub fn create_s3_client(
     client_config: ClientConfig,
+    pool: PagedPool,
     s3_path: &S3Path,
     personality: Option<S3Personality>,
 ) -> anyhow::Result<(S3CrtClient, Runtime, S3Personality)> {
     let client = client_config
-        .create_client(Some(s3_path))
+        .create_client(pool, Some(s3_path))
         .context("Failed to create S3 client")?;
 
     let runtime = Runtime::new(client.event_loop_group());


### PR DESCRIPTION
Adds a command line flag to benchmarks to switch between our pool and the CRT pool.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
